### PR TITLE
Whats wrong with jit grunt

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -172,10 +172,9 @@ module.exports = (grunt) ->
 
 	# These plugins provide necessary tasks.
 	require('time-grunt')(grunt)
-	require('jit-grunt')(grunt)
-
-	# Custom plugins.
-	grunt.loadTasks './grunt-custom-tasks/'
+	require('jit-grunt')(grunt)({
+		customTasksDir: './grunt-custom-tasks/'
+	})
 
 	# Custom tasks.
 	grunt.registerTask 'check', ['mustcontain', 'coffeelint', 'jshint:all']

--- a/grunt-custom-tasks/jscoverage_report.coffee
+++ b/grunt-custom-tasks/jscoverage_report.coffee
@@ -24,8 +24,11 @@ module.exports = (grunt) ->
 		if showOnly?
 			files = Object.keys(_$jscoverage)
 			shallDelete = files.filter (x) -> not x.match(showOnly)
+			console.log 'deleting this:', shallDelete
 			for key in shallDelete
+				console.log('before', key, key of _$jscoverage)
 				delete _$jscoverage[key]
+				console.log('after', key, key of _$jscoverage)
 		# out
 		exports.coverageDetail()
 

--- a/grunt-custom-tasks/jscoverage_report.coffee
+++ b/grunt-custom-tasks/jscoverage_report.coffee
@@ -14,6 +14,8 @@
 
 'use strict'
 
+require 'sugar'
+
 module.exports = (grunt) ->
 	# Please see the Grunt documentation for more information regarding task
 	# creation: http://gruntjs.com/creating-tasks
@@ -22,13 +24,8 @@ module.exports = (grunt) ->
 		showOnly = @options().showOnly
 		# filter
 		if showOnly?
-			files = Object.keys(_$jscoverage)
-			shallDelete = files.filter (x) -> not x.match(showOnly)
-			console.log 'deleting this:', shallDelete
-			for key in shallDelete
-				console.log('before', key, key of _$jscoverage)
-				delete _$jscoverage[key]
-				console.log('after', key, key of _$jscoverage)
+			newCoverage = Object.findAll(_$jscoverage, (file,_) -> file.match(showOnly))
+			eval '_$jscoverage = newCoverage'
 		# out
 		exports.coverageDetail()
 


### PR DESCRIPTION
Не уверен, что основная проблема в `jit-grunt`, но проявляется она после переключения на его `customTasksDir`.
Каким-то неведомым образом падает строка `delete _$jscoverage[key]`, причём обе переменные определены.
Падает так:
```
...
before lib-cov/game.js true
after lib-cov/game.js false
before grunt-custom-tasks/jscoverage_report.coffee true

TypeError: Cannot read property '20' of undefined
  at jscmd (/home/zblzgamer/git/uonline/tests/health-check.coffee:15:2)
  at Object.<anonymous> (/home/zblzgamer/git/uonline/grunt-custom-tasks/jscoverage_report.coffee:81:10)
  at Object.thisTask.fn (/home/zblzgamer/git/uonline/node_modules/grunt/lib/grunt/task.js:82:16)
  at Object.task.fn (/home/zblzgamer/git/uonline/node_modules/jit-grunt/lib/jit-grunt.js:122:30)
  at Object.<anonymous> (/home/zblzgamer/git/uonline/node_modules/grunt/lib/util/task.js:301:30)
  at Task.runTaskFn (/home/zblzgamer/git/uonline/node_modules/grunt/lib/util/task.js:251:24)
  at Task.<anonymous> (/home/zblzgamer/git/uonline/node_modules/grunt/lib/util/task.js:300:12)
  at /home/zblzgamer/git/uonline/node_modules/grunt/lib/util/task.js:227:11
  at process._tickCallback (node.js:355:11)
```